### PR TITLE
Add Interest calculations

### DIFF
--- a/src/server/client.js
+++ b/src/server/client.js
@@ -55,6 +55,13 @@ class Client {
           effectiveLine: calcCurrentPropLine(store.getState().app, payload.propGroupId, payload.propId)
         })
       });
+    } else if (action.type === sharedActionTypes.ADD_WINNING_PROP) {
+      action = Object.assign({}, action, {
+        payload: Object.assign({}, action.payload, {
+          msTimeStamp: moment().format('x')
+        })
+      });
+
     }
 
     if (isValidAction(action, this.getUserId())) {

--- a/src/server/client.js
+++ b/src/server/client.js
@@ -61,7 +61,6 @@ class Client {
           msTimeStamp: moment().format('x')
         })
       });
-
     }
 
     if (isValidAction(action, this.getUserId())) {

--- a/src/shared/__TEST__/.eslintrc
+++ b/src/shared/__TEST__/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "mocha": true,
+    "browser": false, // Not Working! See https://github.com/eslint/eslint/issues/3915
+    "node": true
+  }
+}

--- a/src/shared/__TEST__/selectors.spec.js
+++ b/src/shared/__TEST__/selectors.spec.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const {assert} = require('chai');
+const moment = require('moment');
+const {_exportsForTests: {calcTotalInterestForBet}} = require('../selectors');
+
+// This may be overzealous constantness but my test descs & data got out-of-sync a couple times.
+const DEC_01_2016 = '2016-12-01';
+const DEC_15_2016 = '2016-12-15';
+const JAN_15_2017 = '2017-01-15';
+const FEB_28_2017 = '2017-02-28';
+
+const TEN = 10;
+const ZERO = 0;
+const TWENTY_FIVE = 25;
+
+const MOMENT_FORMAT = 'YYYY-MM-DD';
+
+describe('selectors', () => {
+  describe('calcTotalInterestPayments()', () => {
+    const dec15th2016 = moment(DEC_15_2016, MOMENT_FORMAT);
+    const bubbles = 100;
+    const interest = .1;
+    // Date format: YYYY-MM-DD
+    describe(`when a 100 bubble bet was on ${DEC_15_2016} at 10%`, () => {
+      describe(`when today is ${JAN_15_2017}`, () => {
+        const jan15th2017 = moment(JAN_15_2017, MOMENT_FORMAT);
+        it(`should return an interest value of ${TEN}`, () => {
+          assert.strictEqual(
+            calcTotalInterestForBet(bubbles, interest, dec15th2016, jan15th2017),
+            TEN
+          );
+        });
+      });
+      describe(`when today is ${FEB_28_2017}`, () => {
+        const feb28th2017 = moment(FEB_28_2017, MOMENT_FORMAT);
+        it(`should return an interest value of ${TWENTY_FIVE}`, () => {
+          assert.strictEqual(
+            calcTotalInterestForBet(bubbles, interest, dec15th2016, feb28th2017),
+            TWENTY_FIVE
+          );
+        });
+      });
+      describe(`when today matches the calc date (${DEC_15_2016})`, () => {
+        it(`should return interest value of ${ZERO}`, () => {
+          assert.strictEqual(
+            calcTotalInterestForBet(bubbles, interest, dec15th2016, dec15th2016),
+            ZERO
+          );
+        });
+      });
+    });
+    describe('when a 100 bubble bet was made after the interest calc date', () => {
+      // Note: I can imagine this situation arising in a report that displays interest accumlations overtime.
+      const betDate = moment(DEC_15_2016, MOMENT_FORMAT);
+      const calcAsOfDate = moment(DEC_01_2016, MOMENT_FORMAT);
+      it(`should return an interest value of ${ZERO}`, () => {
+        assert.strictEqual(
+          calcTotalInterestForBet(bubbles, interest, betDate, calcAsOfDate),
+          ZERO
+        );
+      });
+    });
+    describe(`when a 100 bubble bet was on ${DEC_15_2016} at 0%`, () => {
+      const jan15th2017 = moment(DEC_15_2016, MOMENT_FORMAT);
+      const interest = 0;
+      describe(`when today is ${JAN_15_2017}`, () => {
+        it(`should return an interest value of ${ZERO}`, () => {
+          assert.strictEqual(
+            calcTotalInterestForBet(bubbles, interest, dec15th2016, jan15th2017),
+            ZERO
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/shared/__TEST__/selectors.spec.js
+++ b/src/shared/__TEST__/selectors.spec.js
@@ -21,7 +21,6 @@ describe('selectors', () => {
     const dec15th2016 = moment(DEC_15_2016, MOMENT_FORMAT);
     const bubbles = 100;
     const interest = .1;
-    // Date format: YYYY-MM-DD
     describe(`when a 100 bubble bet was on ${DEC_15_2016} at 10%`, () => {
       describe(`when today is ${JAN_15_2017}`, () => {
         const jan15th2017 = moment(JAN_15_2017, MOMENT_FORMAT);

--- a/src/shared/__TEST__/selectors.spec.js
+++ b/src/shared/__TEST__/selectors.spec.js
@@ -2,7 +2,7 @@
 
 const {assert} = require('chai');
 const moment = require('moment');
-const {_exportsForTests: {calcTotalInterestForBet}} = require('../selectors');
+const {calcTotalInterestForBet} = require('../selectors');
 
 // This may be overzealous constantness but my test descs & data got out-of-sync a couple times.
 const DEC_01_2016 = '2016-12-01';

--- a/src/webclient/components/header-bar.js
+++ b/src/webclient/components/header-bar.js
@@ -36,7 +36,7 @@ class HeaderBar extends React.Component {
           }
           <div style={linksContainerStyle}>
             <Link style={linkActiveStyle} to="/props">Props</Link>
-            <Link style={linkActiveStyle} to="/bets">Live Bets</Link>
+            <Link style={linkActiveStyle} to="/bets">All Bets</Link>
             <Link style={linkActiveStyle} to="/prizes">Prizes</Link>
             {
               this.props.isAuthenticated

--- a/src/webclient/containers/bet-list.js
+++ b/src/webclient/containers/bet-list.js
@@ -2,19 +2,31 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const moment = require('moment');
+const _ = require('lodash');
 const {
   getPropGroupLabel,
-  getPropLabel
+  getPropLabel,
+  calcTotalInterestForBet,
+  getPropGroupInterestValue,
+  getInterestCalcAsOfMoment
 } = require('../../shared/selectors');
 
 const {PropTypes} = React;
 
+// TODO: show interest % and returned
 @connect(({app}, {route: {auth}}) => ({
   username: auth.getUsername(),
   bets: app.bets.map((b) =>
     Object.assign({}, b, {
       propGroupLabel: getPropGroupLabel(app, b.propGroupId),
-      propLabel: getPropLabel(app, b.propGroupId, b.propId)
+      propLabel: getPropLabel(app, b.propGroupId, b.propId),
+      propGroupInterest: _.find(app.propGroups, {id: b.propGroupId}).interest,
+      interestPaid: calcTotalInterestForBet(
+        b.bubbles,
+        getPropGroupInterestValue(app, b.propGroupId),
+        moment(b.msTimeStamp, 'x'),
+        getInterestCalcAsOfMoment(app, b.propGroupId, b.propId)
+      )
     })
   )
 }))
@@ -44,6 +56,8 @@ class BetList extends React.Component {
           <div style={rightAlignedHeaderStyle}>Prop Group</div>
           <div style={rightAlignedHeaderStyle}>Prop Label</div>
           <div style={rightAlignedHeaderStyle}>Effective Line</div>
+          <div style={rightAlignedHeaderStyle}>Interest</div>
+          <div style={rightAlignedHeaderStyle}>Interest Paid</div>
           <div style={rightAlignedHeaderStyle}>Date</div>
         </div>
         {
@@ -58,6 +72,8 @@ class BetList extends React.Component {
               <div style={rightAlignedCellStyle}>{bet.propGroupLabel}</div>
               <div style={rightAlignedCellStyle}>{bet.propLabel}</div>
               <div style={rightAlignedCellStyle}>{bet.effectiveLine}</div>
+              <div style={rightAlignedCellStyle}>{bet.propGroupInterest}%</div>
+              <div style={rightAlignedCellStyle}>{bet.interestPaid}</div>
               <div style={rightAlignedCellStyle}>
                 {
                   bet.msTimeStamp === '1488653041267'

--- a/src/webclient/containers/bet-list.js
+++ b/src/webclient/containers/bet-list.js
@@ -13,7 +13,6 @@ const {
 
 const {PropTypes} = React;
 
-// TODO: show interest % and returned
 @connect(({app}, {route: {auth}}) => ({
   username: auth.getUsername(),
   bets: app.bets.map((b) =>


### PR DESCRIPTION
 - Add interest payments (calculated daily)
 - Update bet list to show Prop Group Interest and Interest Paid
 - Stamp current time for winning props so we won't calc interest indefinitely